### PR TITLE
fixing cloud-config generation for drop-in units

### DIFF
--- a/pkg/generator/templates/cloud-init-ubuntu.template
+++ b/pkg/generator/templates/cloud-init-ubuntu.template
@@ -36,7 +36,7 @@ write_files:
 - path: '{{ $dropIn.Path }}'
   encoding: b64
   content: |
-    {{ $dropIn.Content }}
+    {{printf "%s\n" $dropIn.Content}}
 {{- end -}}
 {{- end -}}
 {{- end }}

--- a/pkg/generator/testfiles/cloud-init
+++ b/pkg/generator/testfiles/cloud-init
@@ -19,6 +19,7 @@ write_files:
   encoding: b64
   content: |
     b3ZlcnJpZGU=
+
 runcmd:
 - until apt-get update -qq && apt-get install --no-upgrade -qqy docker.io socat nfs-common logrotate jq policykit-1; do sleep 1; done
 - systemctl daemon-reload

--- a/pkg/generator/testfiles/cloud-init-with-drop-in
+++ b/pkg/generator/testfiles/cloud-init-with-drop-in
@@ -1,0 +1,31 @@
+#cloud-config
+apt_update: true
+write_files:
+- path: '/etc/systemd/system/containerd.service.d/11-exec_config.conf'
+  permissions: '0644'
+  encoding: b64
+  content: |
+    W1NlcnZpY2VdCkV4ZWNTdGFydD0KRXhlY1N0YXJ0PS91c3IvYmluL2NvbnRhaW5lcmQgLS1jb25maWc9L2V0Yy9jb250YWluZXJkL2NvbmZpZy50b21s
+- path: '/etc/systemd/system/containerd.service.d/10-exec-start-pre-init-config.conf'
+  encoding: b64
+  content: |
+    CQpbU2VydmljZV0KRXhlY1N0YXJ0UHJlPS9vcHQvYmluL2luaXQtY29udGFpbmVyZA==
+- path: '/etc/systemd/system/containerd.service.d/12-exec-start-pre-init-config.conf'
+  encoding: b64
+  content: |
+    CQpbU2VydmljZV0KRXhlY1N0YXJ0UHJlPS9vcHQvYmluL2luaXQtY29udGFpbmVyZA==
+- path: '/etc/systemd/system/mtu-customizer.service'
+  encoding: b64
+  content: |
+    CQpbU2VydmljZV0KRXhlY1N0YXJ0UHJlPS9vcHQvYmluL2luaXQtY29udGFpbmVyZA==
+- path: '/etc/systemd/system/other.service'
+  encoding: b64
+  content: |
+    CQpbU2VydmljZV0KRXhlY1N0YXJ0UHJlPS9vcHQvYmluL2luaXQtY29udGFpbmVyZA==
+
+runcmd:
+- until apt-get update -qq && apt-get install --no-upgrade -qqy docker.io socat nfs-common logrotate jq policykit-1; do sleep 1; done
+- systemctl daemon-reload
+- systemctl enable 'containerd.service' && systemctl restart 'containerd.service'
+- systemctl enable 'mtu-customizer.service' && systemctl restart 'mtu-customizer.service'
+- systemctl enable 'other.service' && systemctl restart 'other.service'


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes cloud-config drop-in unit generation.
This is the root cause that lead to failures when [generation the CloudConfig for containerd](https://github.com/gardener/gardener/issues/2058). 

Makes sure to add a newline when adding the drop-in unit content to avoid:

```yaml
- path: '/etc/systemd/system/containerd.service.d/10-exec-start-pre-init-config.conf'
  encoding: b64
  content: |
      W1NlcnZpY2VdCkV4ZWNTdGFydFByZT0vb3B0L2Jpbi9pbml0LWNvbnRhaW5lcmQK- path: '/etc/systemd/system/custom-mtu.service'
  encoding: b64
  content: |
      W1VuaXRdCiAgICBEZXNjcmlwdGlvbj1BcHBseSBhIGN1c3RvbSBNVFUgdG8gdGhlIGRlZmF1bHQgbmV0d29yayBpbnRlcmZhY2UKICAgIFJlcXVpcmVzPWV0aDAubmV0d29yawoKW1NlcnZpY2VdCiAgICBUeXBlPW9uZXNob3QKICAgIFJlbWFpbkFmdGVyRXhpdD15ZXMKICAgIEV4ZWNTdGFydD0vdmFyL2xpYi9tdHUtY3VzdG9taXplci9tdHUtY3VzdG9taXplci5zaA==
```

but rather have 
```yaml
- path: '/etc/systemd/system/containerd.service.d/10-exec-start-pre-init-config.conf'
  encoding: b64
  content: |
    W1NlcnZpY2VdCkV4ZWNTdGFydFByZT0vb3B0L2Jpbi9pbml0LWNvbnRhaW5lcmQK
- path: '/etc/systemd/system/custom-mtu.service'
  encoding: b64
  content: |
      W1VuaXRdCiAgICBEZXNjcmlwdGlvbj1BcHBseSBhIGN1c3RvbSBNVFUgdG8gdGhlIGRlZmF1bHQgbmV0d29yayBpbnRlcmZhY2UKICAgIFJlcXVpcmVzPWV0aDAubmV0d29yawoKW1NlcnZpY2VdCiAgICBUeXBlPW9uZXNob3QKICAgIFJlbWFpbkFmdGVyRXhpdD15ZXMKICAgIEV4ZWNTdGFydD0vdmFyL2xpYi9tdHUtY3VzdG9taXplci9tdHUtY3VzdG9taXplci5zaA==
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator

```
