### PR TITLE
Run generate to populate pack2 code

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM golang:1.13.8 AS builder
 
 WORKDIR /go/src/github.com/gardener/gardener-extension-os-ubuntu
 COPY . .
-RUN make install
+RUN make install-requirements && make generate && make install
 
 ############# gardener-extension-os-ubuntu
 FROM alpine:3.11.3 AS gardener-extension-os-ubuntu


### PR DESCRIPTION
**What this PR does / why we need it**:
The controller currently is failing with:

```
$ k -n extension-os-ubuntu-77t9s logs gardener-extension-os-ubuntu-7d69dc745f-tlpfs -f
panic: stat /templates/cloud-init-ubuntu.template: no such file or directory

goroutine 1 [running]:
k8s.io/apimachinery/pkg/util/runtime.Must(...)
	/go/src/github.com/gardener/gardener-extension-os-ubuntu/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:171
github.com/gardener/gardener-extension-os-ubuntu/pkg/generator.init.0()
	/go/src/github.com/gardener/gardener-extension-os-ubuntu/pkg/generator/generator.go:31 +0x245
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
