### PR TITLE
Fix cloud init generation for CRI containerd

### DIFF
--- a/pkg/generator/templates/cloud-init-ubuntu.template
+++ b/pkg/generator/templates/cloud-init-ubuntu.template
@@ -8,7 +8,7 @@ write_files:
   content: |
     bmV0d29yazoKICBjb25maWc6IGRpc2FibGVkCg==
 {{ end -}}
-{{ if isContainerDEnabled .CRI -}}
+{{ if and (isContainerDEnabled .CRI)  .Bootstrap -}}
 - path: '/etc/systemd/system/containerd.service.d/11-exec_config.conf'
   permissions: '0644'
   encoding: b64
@@ -44,9 +44,13 @@ runcmd:
 - until apt-get update -qq && apt-get install --no-upgrade -qqy docker.io socat nfs-common logrotate jq policykit-1; do sleep 1; done
 - systemctl daemon-reload
 {{ if .Bootstrap -}}
+{{- if isContainerDEnabled .CRI }}
+- systemctl enable containerd && systemctl restart containerd
+{{- else -}}
 - ln -s /usr/bin/docker /bin/docker
 - ln -sf /run/systemd/resolve/resolv.conf /etc/resolv.conf
 - systemctl restart docker
+{{ end }}
 {{ end -}}
 {{ range $_, $unit := .Units -}}
 - systemctl enable '{{ $unit.Name }}' && systemctl restart '{{ $unit.Name }}'

--- a/pkg/generator/testfiles/cloud-init
+++ b/pkg/generator/testfiles/cloud-init
@@ -26,4 +26,5 @@ runcmd:
 - ln -s /usr/bin/docker /bin/docker
 - ln -sf /run/systemd/resolve/resolv.conf /etc/resolv.conf
 - systemctl restart docker
+
 - systemctl enable 'docker.service' && systemctl restart 'docker.service'

--- a/pkg/generator/testfiles/cloud-init-containerd-provision
+++ b/pkg/generator/testfiles/cloud-init-containerd-provision
@@ -1,6 +1,11 @@
 #cloud-config
 apt_update: true
 write_files:
+- path: '/etc/cloud/cloud.cfg.d/custom-networking.cfg'
+  permissions: '0644'
+  encoding: b64
+  content: |
+    bmV0d29yazoKICBjb25maWc6IGRpc2FibGVkCg==
 - path: '/etc/systemd/system/containerd.service.d/11-exec_config.conf'
   permissions: '0644'
   encoding: b64
@@ -10,3 +15,5 @@ write_files:
 runcmd:
 - until apt-get update -qq && apt-get install --no-upgrade -qqy docker.io socat nfs-common logrotate jq policykit-1; do sleep 1; done
 - systemctl daemon-reload
+
+- systemctl enable containerd && systemctl restart containerd

--- a/pkg/generator/testfiles/cloud-init-containerd-reconcile
+++ b/pkg/generator/testfiles/cloud-init-containerd-reconcile
@@ -1,0 +1,7 @@
+#cloud-config
+apt_update: true
+write_files:
+
+runcmd:
+- until apt-get update -qq && apt-get install --no-upgrade -qqy docker.io socat nfs-common logrotate jq policykit-1; do sleep 1; done
+- systemctl daemon-reload

--- a/pkg/generator/testfiles/cloud-init-with-drop-in
+++ b/pkg/generator/testfiles/cloud-init-with-drop-in
@@ -1,16 +1,11 @@
 #cloud-config
 apt_update: true
 write_files:
-- path: '/etc/systemd/system/containerd.service.d/11-exec_config.conf'
-  permissions: '0644'
-  encoding: b64
-  content: |
-    W1NlcnZpY2VdCkV4ZWNTdGFydD0KRXhlY1N0YXJ0PS91c3IvYmluL2NvbnRhaW5lcmQgLS1jb25maWc9L2V0Yy9jb250YWluZXJkL2NvbmZpZy50b21s
-- path: '/etc/systemd/system/containerd.service.d/10-exec-start-pre-init-config.conf'
+- path: '/etc/systemd/system/abc.service.d/10-exec-start-pre-init-config.conf'
   encoding: b64
   content: |
     CQpbU2VydmljZV0KRXhlY1N0YXJ0UHJlPS9vcHQvYmluL2luaXQtY29udGFpbmVyZA==
-- path: '/etc/systemd/system/containerd.service.d/12-exec-start-pre-init-config.conf'
+- path: '/etc/systemd/system/abc.service.d/12-exec-start-pre-init-config.conf'
   encoding: b64
   content: |
     CQpbU2VydmljZV0KRXhlY1N0YXJ0UHJlPS9vcHQvYmluL2luaXQtY29udGFpbmVyZA==
@@ -26,6 +21,6 @@ write_files:
 runcmd:
 - until apt-get update -qq && apt-get install --no-upgrade -qqy docker.io socat nfs-common logrotate jq policykit-1; do sleep 1; done
 - systemctl daemon-reload
-- systemctl enable 'containerd.service' && systemctl restart 'containerd.service'
+- systemctl enable 'abc.service' && systemctl restart 'abc.service'
 - systemctl enable 'mtu-customizer.service' && systemctl restart 'mtu-customizer.service'
 - systemctl enable 'other.service' && systemctl restart 'other.service'


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix cloud init generation for CRI containerd.

During Bootstrap when CRI is enabled,  it 
 - should create /etc/systemd/system/containerd.service.d/11-exec_config.conf 
 - should enable & restart the containerd service

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
The user-data for CRI `containerd` creates the containerd drop-in file and enables & restarts the containerd service.
```
