### PR TITLE
Do not require docker to be enabled to bootstrap CRI nodes (containerd)

### DIFF
--- a/pkg/generator/templates/cloud-init-ubuntu.template
+++ b/pkg/generator/templates/cloud-init-ubuntu.template
@@ -41,15 +41,19 @@ write_files:
 {{- end -}}
 {{- end }}
 runcmd:
+{{- if isContainerDEnabled .CRI }}
+- until apt-get update -qq && apt-get install --no-upgrade -qqy containerd socat nfs-common logrotate jq policykit-1; do sleep 1; done
+{{- else }}
 - until apt-get update -qq && apt-get install --no-upgrade -qqy docker.io socat nfs-common logrotate jq policykit-1; do sleep 1; done
+{{- end }}
 - systemctl daemon-reload
 {{ if .Bootstrap -}}
-{{- if isContainerDEnabled .CRI }}
+{{- if isContainerDEnabled .CRI -}}
 - systemctl enable containerd && systemctl restart containerd
 {{- else -}}
 - ln -s /usr/bin/docker /bin/docker
 - ln -sf /run/systemd/resolve/resolv.conf /etc/resolv.conf
-- systemctl restart docker
+- systemctl enable docker.service && systemctl enable docker.socket && systemctl restart docker
 {{ end }}
 {{ end -}}
 {{ range $_, $unit := .Units -}}

--- a/pkg/generator/testfiles/cloud-init
+++ b/pkg/generator/testfiles/cloud-init
@@ -25,6 +25,6 @@ runcmd:
 - systemctl daemon-reload
 - ln -s /usr/bin/docker /bin/docker
 - ln -sf /run/systemd/resolve/resolv.conf /etc/resolv.conf
-- systemctl restart docker
+- systemctl enable docker.service && systemctl enable docker.socket && systemctl restart docker
 
 - systemctl enable 'docker.service' && systemctl restart 'docker.service'

--- a/pkg/generator/testfiles/cloud-init-containerd-provision
+++ b/pkg/generator/testfiles/cloud-init-containerd-provision
@@ -13,7 +13,6 @@ write_files:
     W1NlcnZpY2VdCkV4ZWNTdGFydD0KRXhlY1N0YXJ0PS91c3IvYmluL2NvbnRhaW5lcmQgLS1jb25maWc9L2V0Yy9jb250YWluZXJkL2NvbmZpZy50b21s
 
 runcmd:
-- until apt-get update -qq && apt-get install --no-upgrade -qqy docker.io socat nfs-common logrotate jq policykit-1; do sleep 1; done
+- until apt-get update -qq && apt-get install --no-upgrade -qqy containerd socat nfs-common logrotate jq policykit-1; do sleep 1; done
 - systemctl daemon-reload
-
 - systemctl enable containerd && systemctl restart containerd

--- a/pkg/generator/testfiles/cloud-init-containerd-reconcile
+++ b/pkg/generator/testfiles/cloud-init-containerd-reconcile
@@ -3,5 +3,5 @@ apt_update: true
 write_files:
 
 runcmd:
-- until apt-get update -qq && apt-get install --no-upgrade -qqy docker.io socat nfs-common logrotate jq policykit-1; do sleep 1; done
+- until apt-get update -qq && apt-get install --no-upgrade -qqy containerd socat nfs-common logrotate jq policykit-1; do sleep 1; done
 - systemctl daemon-reload


### PR DESCRIPTION
**What this PR does / why we need it**:

With [refactorings to the Gardener node bootstrap process for CRI enabled worker groups](https://github.com/gardener/gardener/pull/2739), docker is not strictly required any more for bootstrapping. 
Therefore this PR, when CRI `containerd` is used, only makes sure that `containerd` is installed, enabled & started.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Is only safe to use with a Gardener version that includes [this PR](https://github.com/gardener/gardener/pull/2739).
Most likely it will work also without the mentioned PR together with the Gardener as in Ubuntu, docker.socket and docker.service are usually vendor pre-enabled (therefore started).
- I will add a compatibility notice into the docs as soon as Gardener is released. Until then we can keep this PR in draft.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Do not require docker.service to be enabled to bootstrap CRI nodes (currently only containerd).
```
