### PR TITLE
Add qemu-guest-agent package as it's needed by kubevirt networking

### DIFF
--- a/pkg/generator/templates/cloud-init-ubuntu.template
+++ b/pkg/generator/templates/cloud-init-ubuntu.template
@@ -42,7 +42,9 @@ write_files:
 {{- end }}
 runcmd:
 - until apt-get update -qq && apt-get install --no-upgrade -qqy docker.io socat nfs-common logrotate jq policykit-1; do sleep 1; done
+- if dmidecode | grep -i -e manufacturer | grep -i -q kubevirt; then until apt-get install --no-upgrade -qqy qemu-guest-agent; do sleep 1; done; fi
 - systemctl daemon-reload
+- if systemctl --all --type service | grep -i -q qemu-guest-agent; then systemctl enable 'qemu-guest-agent' && systemctl restart 'qemu-guest-agent'; fi
 {{ if .Bootstrap -}}
 {{- if isContainerDEnabled .CRI }}
 - systemctl enable containerd && systemctl restart containerd

--- a/pkg/generator/testfiles/cloud-init
+++ b/pkg/generator/testfiles/cloud-init
@@ -22,7 +22,9 @@ write_files:
 
 runcmd:
 - until apt-get update -qq && apt-get install --no-upgrade -qqy docker.io socat nfs-common logrotate jq policykit-1; do sleep 1; done
+- if dmidecode | grep -i -e manufacturer | grep -i -q kubevirt; then until apt-get install --no-upgrade -qqy qemu-guest-agent; do sleep 1; done; fi
 - systemctl daemon-reload
+- if systemctl --all --type service | grep -i -q qemu-guest-agent; then systemctl enable 'qemu-guest-agent' && systemctl restart 'qemu-guest-agent'; fi
 - ln -s /usr/bin/docker /bin/docker
 - ln -sf /run/systemd/resolve/resolv.conf /etc/resolv.conf
 - systemctl restart docker

--- a/pkg/generator/testfiles/cloud-init-containerd-provision
+++ b/pkg/generator/testfiles/cloud-init-containerd-provision
@@ -14,6 +14,8 @@ write_files:
 
 runcmd:
 - until apt-get update -qq && apt-get install --no-upgrade -qqy docker.io socat nfs-common logrotate jq policykit-1; do sleep 1; done
+- if dmidecode | grep -i -e manufacturer | grep -i -q kubevirt; then until apt-get install --no-upgrade -qqy qemu-guest-agent; do sleep 1; done; fi
 - systemctl daemon-reload
+- if systemctl --all --type service | grep -i -q qemu-guest-agent; then systemctl enable 'qemu-guest-agent' && systemctl restart 'qemu-guest-agent'; fi
 
 - systemctl enable containerd && systemctl restart containerd

--- a/pkg/generator/testfiles/cloud-init-containerd-reconcile
+++ b/pkg/generator/testfiles/cloud-init-containerd-reconcile
@@ -4,4 +4,6 @@ write_files:
 
 runcmd:
 - until apt-get update -qq && apt-get install --no-upgrade -qqy docker.io socat nfs-common logrotate jq policykit-1; do sleep 1; done
+- if dmidecode | grep -i -e manufacturer | grep -i -q kubevirt; then until apt-get install --no-upgrade -qqy qemu-guest-agent; do sleep 1; done; fi
 - systemctl daemon-reload
+- if systemctl --all --type service | grep -i -q qemu-guest-agent; then systemctl enable 'qemu-guest-agent' && systemctl restart 'qemu-guest-agent'; fi

--- a/pkg/generator/testfiles/cloud-init-with-drop-in
+++ b/pkg/generator/testfiles/cloud-init-with-drop-in
@@ -20,7 +20,9 @@ write_files:
 
 runcmd:
 - until apt-get update -qq && apt-get install --no-upgrade -qqy docker.io socat nfs-common logrotate jq policykit-1; do sleep 1; done
+- if dmidecode | grep -i -e manufacturer | grep -i -q kubevirt; then until apt-get install --no-upgrade -qqy qemu-guest-agent; do sleep 1; done; fi
 - systemctl daemon-reload
+- if systemctl --all --type service | grep -i -q qemu-guest-agent; then systemctl enable 'qemu-guest-agent' && systemctl restart 'qemu-guest-agent'; fi
 - systemctl enable 'abc.service' && systemctl restart 'abc.service'
 - systemctl enable 'mtu-customizer.service' && systemctl restart 'mtu-customizer.service'
 - systemctl enable 'other.service' && systemctl restart 'other.service'


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds `qemu-guest-agent` package as it's needed for kubevirt networking to function properly. Without it, the network interface IP address is not propagated to the VMI status, which is important for debugging and for certain scenarios.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```improvement operator
qemu-guest-agent package has been added to the list of packages installed by cloud-init on kubevirt VMs.
```
