### PR TITLE
Do not use cloud config apt-update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ############# builder
-FROM golang:1.14.7 AS builder
+FROM golang:1.14.9 AS builder
 
 WORKDIR /go/src/github.com/gardener/gardener-extension-os-ubuntu
 COPY . .

--- a/pkg/generator/templates/cloud-init-ubuntu.template
+++ b/pkg/generator/templates/cloud-init-ubuntu.template
@@ -1,5 +1,5 @@
 #cloud-config
-apt_update: true
+apt_update: false
 write_files:
 {{ if .Bootstrap -}}
 - path: '/etc/cloud/cloud.cfg.d/custom-networking.cfg'

--- a/pkg/generator/testfiles/cloud-init
+++ b/pkg/generator/testfiles/cloud-init
@@ -1,5 +1,5 @@
 #cloud-config
-apt_update: true
+apt_update: false
 write_files:
 - path: '/etc/cloud/cloud.cfg.d/custom-networking.cfg'
   permissions: '0644'

--- a/pkg/generator/testfiles/cloud-init-containerd-provision
+++ b/pkg/generator/testfiles/cloud-init-containerd-provision
@@ -1,5 +1,5 @@
 #cloud-config
-apt_update: true
+apt_update: false
 write_files:
 - path: '/etc/cloud/cloud.cfg.d/custom-networking.cfg'
   permissions: '0644'

--- a/pkg/generator/testfiles/cloud-init-containerd-reconcile
+++ b/pkg/generator/testfiles/cloud-init-containerd-reconcile
@@ -1,5 +1,5 @@
 #cloud-config
-apt_update: true
+apt_update: false
 write_files:
 
 runcmd:

--- a/pkg/generator/testfiles/cloud-init-with-drop-in
+++ b/pkg/generator/testfiles/cloud-init-with-drop-in
@@ -1,5 +1,5 @@
 #cloud-config
-apt_update: true
+apt_update: false
 write_files:
 - path: '/etc/systemd/system/abc.service.d/10-exec-start-pre-init-config.conf'
   encoding: b64


### PR DESCRIPTION
**What this PR does / why we need it**:
Do not use the cloud config apt-update.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
The extension now relies only on the bash snippet to update apt cache.
```

```improvement operator
The golang has been updated to 1.14.9.
```
