### PR TITLE
Let cloud-init manage /etc/hosts file

### DIFF
--- a/pkg/generator/templates/cloud-init-ubuntu.template
+++ b/pkg/generator/templates/cloud-init-ubuntu.template
@@ -1,5 +1,6 @@
 #cloud-config
 apt_update: false
+manage_etc_hosts: true
 write_files:
 {{ if .Bootstrap -}}
 - path: '/etc/cloud/cloud.cfg.d/custom-networking.cfg'

--- a/pkg/generator/testfiles/cloud-init
+++ b/pkg/generator/testfiles/cloud-init
@@ -1,5 +1,6 @@
 #cloud-config
 apt_update: false
+manage_etc_hosts: true
 write_files:
 - path: '/etc/cloud/cloud.cfg.d/custom-networking.cfg'
   permissions: '0644'

--- a/pkg/generator/testfiles/cloud-init-containerd-provision
+++ b/pkg/generator/testfiles/cloud-init-containerd-provision
@@ -1,5 +1,6 @@
 #cloud-config
 apt_update: false
+manage_etc_hosts: true
 write_files:
 - path: '/etc/cloud/cloud.cfg.d/custom-networking.cfg'
   permissions: '0644'

--- a/pkg/generator/testfiles/cloud-init-containerd-reconcile
+++ b/pkg/generator/testfiles/cloud-init-containerd-reconcile
@@ -1,5 +1,6 @@
 #cloud-config
 apt_update: false
+manage_etc_hosts: true
 write_files:
 
 runcmd:

--- a/pkg/generator/testfiles/cloud-init-with-drop-in
+++ b/pkg/generator/testfiles/cloud-init-with-drop-in
@@ -1,5 +1,6 @@
 #cloud-config
 apt_update: false
+manage_etc_hosts: true
 write_files:
 - path: '/etc/systemd/system/abc.service.d/10-exec-start-pre-init-config.conf'
   encoding: b64


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area os
/kind enhancement
/priority normal
/os ubuntu

**What this PR does / why we need it**:
The cloud-init is now managing the `/etc/hosts` file.

**Which issue(s) this PR fixes**:
Fixes #25 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
The `/etc/hosts` file is now populated by cloud-init. This improvement is needed for ubuntu images where the file is not present.
```
