### PR TITLE
Use kaniko and switch back to docker hub images

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -6,6 +6,7 @@ gardener-extension-os-ubuntu:
       version:
         preprocess: 'inject-commit-hash'
       publish:
+        oci-builder: 'kaniko'
         dockerimages:
           gardener-extension-os-ubuntu:
             registry: 'gcr-readwrite'
@@ -41,6 +42,7 @@ gardener-extension-os-ubuntu:
               slack_cfg_name: 'scp_workspace'
         component_descriptor: ~
         publish:
+          oci-builder: 'kaniko'
           dockerimages:
             gardener-extension-os-ubuntu:
               tag_as_latest: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
 ############# builder
-FROM eu.gcr.io/gardener-project/3rd/golang:1.15.7 AS builder
+FROM golang:1.15.8 AS builder
 
 WORKDIR /go/src/github.com/gardener/gardener-extension-os-ubuntu
 COPY . .
 RUN make install-requirements && make generate && make install
 
 ############# gardener-extension-os-ubuntu
-FROM eu.gcr.io/gardener-project/3rd/alpine:3.12.3 AS gardener-extension-os-ubuntu
+FROM alpine:3.13.2 AS gardener-extension-os-ubuntu
 
 COPY --from=builder /go/bin/gardener-extension-os-ubuntu /gardener-extension-os-ubuntu
 ENTRYPOINT ["/gardener-extension-os-ubuntu"]


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement 
/priority normal
/os ubuntu

**What this PR does / why we need it**:
Use kaniko and switch back to docker hub images.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
