### PR TITLE
Switch bootstrap script from cloud-init to bash

### DIFF
--- a/pkg/generator/generator.go
+++ b/pkg/generator/generator.go
@@ -21,7 +21,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/runtime"
 )
 
-var cmd = "/usr/bin/cloud-init clean && /usr/bin/cloud-init --file %s init"
+var cmd = "/usr/bin/env bash %s"
 var cloudInitGenerator *ostemplate.CloudInitGenerator
 
 //go:generate packr2

--- a/pkg/generator/templates/cloud-init-ubuntu.template
+++ b/pkg/generator/templates/cloud-init-ubuntu.template
@@ -1,60 +1,65 @@
-#cloud-config
-apt_update: false
-manage_etc_hosts: true
-write_files:
-{{ if .Bootstrap -}}
-- path: '/etc/cloud/cloud.cfg.d/custom-networking.cfg'
-  permissions: '0644'
-  encoding: b64
-  content: |
-    bmV0d29yazoKICBjb25maWc6IGRpc2FibGVkCg==
-{{ end -}}
-{{ if and (isContainerDEnabled .CRI)  .Bootstrap -}}
-- path: '/etc/systemd/system/containerd.service.d/11-exec_config.conf'
-  permissions: '0644'
-  encoding: b64
-  content: |
-    W1NlcnZpY2VdCkV4ZWNTdGFydD0KRXhlY1N0YXJ0PS91c3IvYmluL2NvbnRhaW5lcmQgLS1jb25maWc9L2V0Yy9jb250YWluZXJkL2NvbmZpZy50b21s
-{{ end -}}
+#!/bin/bash
+
+{{- define "put-content" -}}
+cat << EOF | base64 -d > '{{ .Path }}'
+{{ .Content }}
+EOF
+{{- end -}}
+
+{{ if .Bootstrap }}
+mkdir -p /etc/cloud/cloud.cfg.d/
+cat <<EOF > /etc/cloud/cloud.cfg.d/custom-networking.cfg
+network:
+  config: disabled
+EOF
+chmod 0644 /etc/cloud/cloud.cfg.d/custom-networking.cfg
+{{- end }}
+
+{{ if and (isContainerDEnabled .CRI) .Bootstrap }}
+mkdir -p /etc/systemd/system/containerd.service.d
+cat <<EOF > /etc/systemd/system/containerd.service.d/11-exec_config.conf
+[Service]
+ExecStart=
+ExecStart=/usr/bin/containerd --config=/etc/containerd/config.toml
+EOF
+chmod 0644 /etc/systemd/system/containerd.service.d/11-exec_config.conf
+{{- end }}
+
 {{ range $_, $file := .Files -}}
-- path: '{{ $file.Path }}'
-{{- if $file.Permissions }}
-  permissions: '{{ $file.Permissions }}'
-{{- end }}
-  encoding: b64
-  content: |
-    {{ $file.Content }}
-{{ end -}}
-{{- range $_, $unit := .Units -}}
-{{ if $unit.Content -}}
-- path: '{{ $unit.Path }}'
-  encoding: b64
-  content: |
-    {{ $unit.Content }}
-{{ end -}}
-{{ if $unit.DropIns -}}
-{{ range $_, $dropIn := $unit.DropIns.Items -}}
-- path: '{{ $dropIn.Path }}'
-  encoding: b64
-  content: |
-    {{printf "%s\n" $dropIn.Content}}
-{{- end -}}
-{{- end -}}
-{{- end }}
-runcmd:
-- until apt-get update -qq && apt-get install --no-upgrade -qqy docker.io socat nfs-common logrotate jq policykit-1; do sleep 1; done
-- systemctl daemon-reload
-{{ if .Bootstrap -}}
-{{- if isContainerDEnabled .CRI }}
-- systemctl enable containerd && systemctl restart containerd
-{{- else -}}
-- ln -s /usr/bin/docker /bin/docker
-- ln -sf /run/systemd/resolve/resolv.conf /etc/resolv.conf
-- systemctl restart docker
+mkdir -p '{{ $file.Dirname }}'
+{{ template "put-content" $file }}
+{{ if $file.Permissions -}}
+chmod '{{ $file.Permissions }}' '{{ $file.Path }}'
 {{ end }}
-{{ end -}}
+{{ end }}
+
 {{ range $_, $unit := .Units -}}
+{{ if $unit.Content -}}
+{{ template "put-content" $unit }}
+{{- end }}
+{{ if $unit.DropIns }}
+mkdir -p '{{ $unit.DropIns.Path }}'
+{{ range $_, $dropIn := $unit.DropIns.Items -}}
+{{ template "put-content" $dropIn }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+until apt-get update -qq && apt-get install --no-upgrade -qqy docker.io socat nfs-common logrotate jq policykit-1; do sleep 1; done
+systemctl daemon-reload
+
+{{- if .Bootstrap }}
+{{- if isContainerDEnabled .CRI }}
+systemctl enable containerd && systemctl restart containerd
+{{- else }}
+ln -s /usr/bin/docker /bin/docker
+ln -sf /run/systemd/resolve/resolv.conf /etc/resolv.conf
+systemctl restart docker
+{{- end }}
+{{- end }}
+
+{{- range $_, $unit := .Units }}
 {{- if or (ne $unit.Name "cloud-config-downloader.service") ($.Bootstrap) }}
-- systemctl enable '{{ $unit.Name }}' && systemctl restart '{{ $unit.Name }}'
-{{ end -}}
-{{ end -}}
+systemctl enable '{{ $unit.Name }}' && systemctl restart '{{ $unit.Name }}'
+{{- end }}
+{{- end }}

--- a/pkg/generator/testfiles/cloud-init
+++ b/pkg/generator/testfiles/cloud-init
@@ -1,32 +1,33 @@
-#cloud-config
-apt_update: false
-manage_etc_hosts: true
-write_files:
-- path: '/etc/cloud/cloud.cfg.d/custom-networking.cfg'
-  permissions: '0644'
-  encoding: b64
-  content: |
-    bmV0d29yazoKICBjb25maWc6IGRpc2FibGVkCg==
-- path: '/foo'
-  permissions: '0600'
-  encoding: b64
-  content: |
-    YmFy
-- path: '/etc/systemd/system/docker.service'
-  encoding: b64
-  content: |
-    dW5pdA==
-- path: '/etc/systemd/system/docker.service.d/10-docker-opts.conf'
-  encoding: b64
-  content: |
-    b3ZlcnJpZGU=
-
-runcmd:
-- until apt-get update -qq && apt-get install --no-upgrade -qqy docker.io socat nfs-common logrotate jq policykit-1; do sleep 1; done
-- systemctl daemon-reload
-- ln -s /usr/bin/docker /bin/docker
-- ln -sf /run/systemd/resolve/resolv.conf /etc/resolv.conf
-- systemctl restart docker
+#!/bin/bash
+mkdir -p /etc/cloud/cloud.cfg.d/
+cat <<EOF > /etc/cloud/cloud.cfg.d/custom-networking.cfg
+network:
+  config: disabled
+EOF
+chmod 0644 /etc/cloud/cloud.cfg.d/custom-networking.cfg
 
 
-- systemctl enable 'docker.service' && systemctl restart 'docker.service'
+
+mkdir -p '/'
+cat << EOF | base64 -d > '/foo'
+YmFy
+EOF
+chmod '0600' '/foo'
+
+
+
+cat << EOF | base64 -d > '/etc/systemd/system/docker.service'
+dW5pdA==
+EOF
+
+mkdir -p '/etc/systemd/system/docker.service.d'
+cat << EOF | base64 -d > '/etc/systemd/system/docker.service.d/10-docker-opts.conf'
+b3ZlcnJpZGU=
+EOF
+
+until apt-get update -qq && apt-get install --no-upgrade -qqy docker.io socat nfs-common logrotate jq policykit-1; do sleep 1; done
+systemctl daemon-reload
+ln -s /usr/bin/docker /bin/docker
+ln -sf /run/systemd/resolve/resolv.conf /etc/resolv.conf
+systemctl restart docker
+systemctl enable 'docker.service' && systemctl restart 'docker.service'

--- a/pkg/generator/testfiles/cloud-init-containerd-provision
+++ b/pkg/generator/testfiles/cloud-init-containerd-provision
@@ -1,22 +1,26 @@
-#cloud-config
-apt_update: false
-manage_etc_hosts: true
-write_files:
-- path: '/etc/cloud/cloud.cfg.d/custom-networking.cfg'
-  permissions: '0644'
-  encoding: b64
-  content: |
-    bmV0d29yazoKICBjb25maWc6IGRpc2FibGVkCg==
-- path: '/etc/systemd/system/containerd.service.d/11-exec_config.conf'
-  permissions: '0644'
-  encoding: b64
-  content: |
-    W1NlcnZpY2VdCkV4ZWNTdGFydD0KRXhlY1N0YXJ0PS91c3IvYmluL2NvbnRhaW5lcmQgLS1jb25maWc9L2V0Yy9jb250YWluZXJkL2NvbmZpZy50b21s
+#!/bin/bash
+mkdir -p /etc/cloud/cloud.cfg.d/
+cat <<EOF > /etc/cloud/cloud.cfg.d/custom-networking.cfg
+network:
+  config: disabled
+EOF
+chmod 0644 /etc/cloud/cloud.cfg.d/custom-networking.cfg
 
-runcmd:
-- until apt-get update -qq && apt-get install --no-upgrade -qqy docker.io socat nfs-common logrotate jq policykit-1; do sleep 1; done
-- systemctl daemon-reload
 
-- systemctl enable containerd && systemctl restart containerd
+mkdir -p /etc/systemd/system/containerd.service.d
+cat <<EOF > /etc/systemd/system/containerd.service.d/11-exec_config.conf
+[Service]
+ExecStart=
+ExecStart=/usr/bin/containerd --config=/etc/containerd/config.toml
+EOF
+chmod 0644 /etc/systemd/system/containerd.service.d/11-exec_config.conf
 
-- systemctl enable 'cloud-config-downloader.service' && systemctl restart 'cloud-config-downloader.service'
+
+
+
+
+
+until apt-get update -qq && apt-get install --no-upgrade -qqy docker.io socat nfs-common logrotate jq policykit-1; do sleep 1; done
+systemctl daemon-reload
+systemctl enable containerd && systemctl restart containerd
+systemctl enable 'cloud-config-downloader.service' && systemctl restart 'cloud-config-downloader.service'

--- a/pkg/generator/testfiles/cloud-init-containerd-reconcile
+++ b/pkg/generator/testfiles/cloud-init-containerd-reconcile
@@ -1,8 +1,10 @@
-#cloud-config
-apt_update: false
-manage_etc_hosts: true
-write_files:
+#!/bin/bash
 
-runcmd:
-- until apt-get update -qq && apt-get install --no-upgrade -qqy docker.io socat nfs-common logrotate jq policykit-1; do sleep 1; done
-- systemctl daemon-reload
+
+
+
+
+
+
+until apt-get update -qq && apt-get install --no-upgrade -qqy docker.io socat nfs-common logrotate jq policykit-1; do sleep 1; done
+systemctl daemon-reload

--- a/pkg/generator/testfiles/cloud-init-with-drop-in
+++ b/pkg/generator/testfiles/cloud-init-with-drop-in
@@ -1,30 +1,27 @@
-#cloud-config
-apt_update: false
-manage_etc_hosts: true
-write_files:
-- path: '/etc/systemd/system/abc.service.d/10-exec-start-pre-init-config.conf'
-  encoding: b64
-  content: |
-    W1NlcnZpY2VdCkV4ZWNTdGFydFByZT0vb3B0L2Jpbi9pbml0LWNvbnRhaW5lcmQ=
-- path: '/etc/systemd/system/abc.service.d/12-exec-start-pre-init-config.conf'
-  encoding: b64
-  content: |
-    W1NlcnZpY2VdCkV4ZWNTdGFydFByZT0vb3B0L2Jpbi9pbml0LWNvbnRhaW5lcmQ=
-- path: '/etc/systemd/system/mtu-customizer.service'
-  encoding: b64
-  content: |
-    W1NlcnZpY2VdCkV4ZWNTdGFydFByZT0vb3B0L2Jpbi9pbml0LWNvbnRhaW5lcmQ=
-- path: '/etc/systemd/system/other.service'
-  encoding: b64
-  content: |
-    W1NlcnZpY2VdCkV4ZWNTdGFydFByZT0vb3B0L2Jpbi9pbml0LWNvbnRhaW5lcmQ=
+#!/bin/bash
 
-runcmd:
-- until apt-get update -qq && apt-get install --no-upgrade -qqy docker.io socat nfs-common logrotate jq policykit-1; do sleep 1; done
-- systemctl daemon-reload
 
-- systemctl enable 'abc.service' && systemctl restart 'abc.service'
 
-- systemctl enable 'mtu-customizer.service' && systemctl restart 'mtu-customizer.service'
 
-- systemctl enable 'other.service' && systemctl restart 'other.service'
+
+
+
+mkdir -p '/etc/systemd/system/abc.service.d'
+cat << EOF | base64 -d > '/etc/systemd/system/abc.service.d/10-exec-start-pre-init-config.conf'
+W1NlcnZpY2VdCkV4ZWNTdGFydFByZT0vb3B0L2Jpbi9pbml0LWNvbnRhaW5lcmQ=
+EOFcat << EOF | base64 -d > '/etc/systemd/system/abc.service.d/12-exec-start-pre-init-config.conf'
+W1NlcnZpY2VdCkV4ZWNTdGFydFByZT0vb3B0L2Jpbi9pbml0LWNvbnRhaW5lcmQ=
+EOFcat << EOF | base64 -d > '/etc/systemd/system/mtu-customizer.service'
+W1NlcnZpY2VdCkV4ZWNTdGFydFByZT0vb3B0L2Jpbi9pbml0LWNvbnRhaW5lcmQ=
+EOF
+cat << EOF | base64 -d > '/etc/systemd/system/other.service'
+W1NlcnZpY2VdCkV4ZWNTdGFydFByZT0vb3B0L2Jpbi9pbml0LWNvbnRhaW5lcmQ=
+EOF
+
+
+
+until apt-get update -qq && apt-get install --no-upgrade -qqy docker.io socat nfs-common logrotate jq policykit-1; do sleep 1; done
+systemctl daemon-reload
+systemctl enable 'abc.service' && systemctl restart 'abc.service'
+systemctl enable 'mtu-customizer.service' && systemctl restart 'mtu-customizer.service'
+systemctl enable 'other.service' && systemctl restart 'other.service'


### PR DESCRIPTION
**How to categorize this PR?**
/area os
/kind enhancement
/os ubuntu

**What this PR does / why we need it**:
Switch bootstrap script from cloud-init to bash.

**Which issue(s) this PR fixes**:
Fixes #31 

**Special notes for your reviewer**:
I have tested this change and it is working fine with AWS,Azure, GCP and OpenStack.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
This extension is now using Bash script to bootstrap Ubuntu nodes instead of cloud-init.
```
