### PR TITLE
Support TransmitUnencoded flag

### DIFF
--- a/pkg/generator/templates/cloud-init-ubuntu.template
+++ b/pkg/generator/templates/cloud-init-ubuntu.template
@@ -6,6 +6,12 @@ cat << EOF | base64 -d > '{{ .Path }}'
 EOF
 {{- end -}}
 
+{{- define "put-content-unencoded" -}}
+cat << EOF > '{{ .Path }}'
+{{ .Content }}
+EOF
+{{- end -}}
+
 {{ if .Bootstrap }}
 mkdir -p /etc/cloud/cloud.cfg.d/
 cat <<EOF > /etc/cloud/cloud.cfg.d/custom-networking.cfg
@@ -27,7 +33,11 @@ chmod 0644 /etc/systemd/system/containerd.service.d/11-exec_config.conf
 
 {{ range $_, $file := .Files -}}
 mkdir -p '{{ $file.Dirname }}'
+{{ if $file.TransmitUnencoded -}}
+{{ template "put-content-unencoded" $file }}
+{{- else -}}
 {{ template "put-content" $file }}
+{{- end }}
 {{ if $file.Permissions -}}
 chmod '{{ $file.Permissions }}' '{{ $file.Path }}'
 {{ end }}

--- a/pkg/generator/testfiles/cloud-init
+++ b/pkg/generator/testfiles/cloud-init
@@ -15,7 +15,7 @@ EOF
 chmod '0600' '/foo'
 
 mkdir -p '/'
-cat << EOF | base64 -d > '/foo2'
+cat << EOF > '/foo2'
 bar
 EOF
 


### PR DESCRIPTION
Accepts the flag `Transmit Unencoded`.

Needed for creation of bootstrap-tokens for machines introduced here: https://github.com/gardener/gardener/pull/3902

**How to categorize this PR?**
/area security
/kind enhancement
/os ubuntu

**What this PR does / why we need it**:
See https://github.com/gardener/gardener/issues/3898 and https://github.com/gardener/gardener/pull/3902

**Release note**:
```other operator
Introduces new flag `TransmitUnencoded` which writes file content unencoded into the worker resource.
```
