### PR TITLE
Avoid unnecessary restart of systemd services

### DIFF
--- a/pkg/generator/generator_test.go
+++ b/pkg/generator/generator_test.go
@@ -68,6 +68,14 @@ var _ = Describe("Ubuntu OS Generator Test", func() {
 			expectedCloudInit, err := testfiles.Files.ReadFile("cloud-init-containerd-reconcile")
 			Expect(err).NotTo(HaveOccurred())
 			expected := string(expectedCloudInit)
+
+			osc.Files = []*commongen.File{
+				{
+					Path:    "/path",
+					Content: []byte("content"),
+				},
+			}
+
 			osc.Bootstrap = false
 			osc.Object.Spec.Purpose = v1alpha1.OperatingSystemConfigPurposeReconcile
 			cloudInit, _, err := g.Generate(osc)

--- a/pkg/generator/templates/cloud-init-ubuntu.template
+++ b/pkg/generator/templates/cloud-init-ubuntu.template
@@ -55,21 +55,15 @@ mkdir -p '{{ $unit.DropIns.Path }}'
 {{- end }}
 {{- end }}
 
-until apt-get update -qq && apt-get install --no-upgrade -qqy docker.io socat nfs-common logrotate jq policykit-1; do sleep 1; done
-systemctl daemon-reload
 
 {{- if .Bootstrap }}
-{{- if isContainerDEnabled .CRI }}
-systemctl enable containerd && systemctl restart containerd
-{{- else }}
+until apt-get update -qq && apt-get install --no-upgrade -qqy docker.io socat nfs-common logrotate jq policykit-1; do sleep 1; done
 ln -s /usr/bin/docker /bin/docker
 ln -sf /run/systemd/resolve/resolv.conf /etc/resolv.conf
-systemctl restart docker
+systemctl daemon-reload
+{{- if isContainerDEnabled .CRI }}
+systemctl enable containerd && systemctl restart containerd
 {{- end }}
-{{- end }}
-
-{{- range $_, $unit := .Units }}
-{{- if or (ne $unit.Name "cloud-config-downloader.service") ($.Bootstrap) }}
-systemctl enable '{{ $unit.Name }}' && systemctl restart '{{ $unit.Name }}'
-{{- end }}
+systemctl enable docker && systemctl restart docker
+systemctl enable cloud-config-downloader && systemctl restart cloud-config-downloader
 {{- end }}

--- a/pkg/generator/testfiles/cloud-init
+++ b/pkg/generator/testfiles/cloud-init
@@ -29,10 +29,9 @@ mkdir -p '/etc/systemd/system/docker.service.d'
 cat << EOF | base64 -d > '/etc/systemd/system/docker.service.d/10-docker-opts.conf'
 b3ZlcnJpZGU=
 EOF
-
 until apt-get update -qq && apt-get install --no-upgrade -qqy docker.io socat nfs-common logrotate jq policykit-1; do sleep 1; done
-systemctl daemon-reload
 ln -s /usr/bin/docker /bin/docker
 ln -sf /run/systemd/resolve/resolv.conf /etc/resolv.conf
-systemctl restart docker
-systemctl enable 'docker.service' && systemctl restart 'docker.service'
+systemctl daemon-reload
+systemctl enable docker && systemctl restart docker
+systemctl enable cloud-config-downloader && systemctl restart cloud-config-downloader

--- a/pkg/generator/testfiles/cloud-init-containerd-provision
+++ b/pkg/generator/testfiles/cloud-init-containerd-provision
@@ -19,8 +19,10 @@ chmod 0644 /etc/systemd/system/containerd.service.d/11-exec_config.conf
 
 
 
-
 until apt-get update -qq && apt-get install --no-upgrade -qqy docker.io socat nfs-common logrotate jq policykit-1; do sleep 1; done
+ln -s /usr/bin/docker /bin/docker
+ln -sf /run/systemd/resolve/resolv.conf /etc/resolv.conf
 systemctl daemon-reload
 systemctl enable containerd && systemctl restart containerd
-systemctl enable 'cloud-config-downloader.service' && systemctl restart 'cloud-config-downloader.service'
+systemctl enable docker && systemctl restart docker
+systemctl enable cloud-config-downloader && systemctl restart cloud-config-downloader

--- a/pkg/generator/testfiles/cloud-init-containerd-reconcile
+++ b/pkg/generator/testfiles/cloud-init-containerd-reconcile
@@ -2,9 +2,11 @@
 
 
 
+mkdir -p '/'
+cat << EOF | base64 -d > '/path'
+Y29udGVudA==
+EOF
 
 
 
 
-until apt-get update -qq && apt-get install --no-upgrade -qqy docker.io socat nfs-common logrotate jq policykit-1; do sleep 1; done
-systemctl daemon-reload

--- a/pkg/generator/testfiles/cloud-init-with-drop-in
+++ b/pkg/generator/testfiles/cloud-init-with-drop-in
@@ -19,9 +19,3 @@ W1NlcnZpY2VdCkV4ZWNTdGFydFByZT0vb3B0L2Jpbi9pbml0LWNvbnRhaW5lcmQ=
 EOF
 
 
-
-until apt-get update -qq && apt-get install --no-upgrade -qqy docker.io socat nfs-common logrotate jq policykit-1; do sleep 1; done
-systemctl daemon-reload
-systemctl enable 'abc.service' && systemctl restart 'abc.service'
-systemctl enable 'mtu-customizer.service' && systemctl restart 'mtu-customizer.service'
-systemctl enable 'other.service' && systemctl restart 'other.service'


### PR DESCRIPTION
/os ubuntu
/area os
/kind cleanup enhancement

Avoid unnecessary restart of systemd services.
The service restarts are executed by the script maintained in Gardener here https://github.com/gardener/gardener/blob/17de192a8956c28f76a6967daf865592cd3be1f5/pkg/operation/botanist/component/extensions/operatingsystemconfig/executor/templates/scripts/execute-cloud-config.tpl.sh#L162-L166

similar to https://github.com/gardener/gardener-extension-os-gardenlinux/pull/41


```other operator
This extension is no longer restarting the systemd services from the original OperatingSystemConfig units.
```

