### PR TITLE
Set kubelet to not use the sytemd-resolved stub

### DIFF
--- a/pkg/generator/templates/cloud-init-ubuntu.template
+++ b/pkg/generator/templates/cloud-init-ubuntu.template
@@ -55,11 +55,15 @@ mkdir -p '{{ $unit.DropIns.Path }}'
 {{- end }}
 {{- end }}
 
+{{- if not .Bootstrap }}
+if grep -q 'resolvConf: /etc/resolv.conf' /var/lib/kubelet/config/kubelet; then
+  sed -i -e 's|resolvConf: /etc/resolv.conf|resolvConf: /run/systemd/resolve/resolv.conf|g' /var/lib/kubelet/config/kubelet;
+fi
+{{- end }}
 
 {{- if .Bootstrap }}
-until apt-get update -qq && apt-get install --no-upgrade -qqy docker.io socat nfs-common logrotate jq policykit-1; do sleep 1; done
+until apt-get update -qq && apt-get install --no-upgrade -qqy containerd runc docker.io socat nfs-common logrotate jq policykit-1; do sleep 1; done
 ln -s /usr/bin/docker /bin/docker
-ln -sf /run/systemd/resolve/resolv.conf /etc/resolv.conf
 systemctl daemon-reload
 {{- if isContainerDEnabled .CRI }}
 systemctl enable containerd && systemctl restart containerd

--- a/pkg/generator/testfiles/cloud-init
+++ b/pkg/generator/testfiles/cloud-init
@@ -29,9 +29,8 @@ mkdir -p '/etc/systemd/system/docker.service.d'
 cat << EOF | base64 -d > '/etc/systemd/system/docker.service.d/10-docker-opts.conf'
 b3ZlcnJpZGU=
 EOF
-until apt-get update -qq && apt-get install --no-upgrade -qqy docker.io socat nfs-common logrotate jq policykit-1; do sleep 1; done
+until apt-get update -qq && apt-get install --no-upgrade -qqy containerd runc docker.io socat nfs-common logrotate jq policykit-1; do sleep 1; done
 ln -s /usr/bin/docker /bin/docker
-ln -sf /run/systemd/resolve/resolv.conf /etc/resolv.conf
 systemctl daemon-reload
 systemctl enable docker && systemctl restart docker
 systemctl enable cloud-config-downloader && systemctl restart cloud-config-downloader

--- a/pkg/generator/testfiles/cloud-init-containerd-provision
+++ b/pkg/generator/testfiles/cloud-init-containerd-provision
@@ -19,9 +19,8 @@ chmod 0644 /etc/systemd/system/containerd.service.d/11-exec_config.conf
 
 
 
-until apt-get update -qq && apt-get install --no-upgrade -qqy docker.io socat nfs-common logrotate jq policykit-1; do sleep 1; done
+until apt-get update -qq && apt-get install --no-upgrade -qqy containerd runc docker.io socat nfs-common logrotate jq policykit-1; do sleep 1; done
 ln -s /usr/bin/docker /bin/docker
-ln -sf /run/systemd/resolve/resolv.conf /etc/resolv.conf
 systemctl daemon-reload
 systemctl enable containerd && systemctl restart containerd
 systemctl enable docker && systemctl restart docker

--- a/pkg/generator/testfiles/cloud-init-containerd-reconcile
+++ b/pkg/generator/testfiles/cloud-init-containerd-reconcile
@@ -10,3 +10,6 @@ EOF
 
 
 
+if grep -q 'resolvConf: /etc/resolv.conf' /var/lib/kubelet/config/kubelet; then
+  sed -i -e 's|resolvConf: /etc/resolv.conf|resolvConf: /run/systemd/resolve/resolv.conf|g' /var/lib/kubelet/config/kubelet;
+fi

--- a/pkg/generator/testfiles/cloud-init-with-drop-in
+++ b/pkg/generator/testfiles/cloud-init-with-drop-in
@@ -19,3 +19,6 @@ W1NlcnZpY2VdCkV4ZWNTdGFydFByZT0vb3B0L2Jpbi9pbml0LWNvbnRhaW5lcmQ=
 EOF
 
 
+if grep -q 'resolvConf: /etc/resolv.conf' /var/lib/kubelet/config/kubelet; then
+  sed -i -e 's|resolvConf: /etc/resolv.conf|resolvConf: /run/systemd/resolve/resolv.conf|g' /var/lib/kubelet/config/kubelet;
+fi


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area os
/kind bug
/os ubuntu

**What this PR does / why we need it**:
Set kubelet to not use the sytemd-resolved stub
More info in https://kubernetes.io/docs/tasks/administer-cluster/dns-debugging-resolution/#known-issues

**Which issue(s) this PR fixes**:
Fixes #50 

**Special notes for your reviewer**:
There is another way to fix this problem. I could have configured extra args for the kubelet and set `--resolv-conf=/run/systemd/resolve/resolv.conf`, but this command line paramters is deprecated, therefore I decided to go in the kubelet configuration file.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fix a bug that was affecting the DNS resolution for containers running on the node due to usage of systemd-resolved stub i.e. the node local DNS server 127.0.0.53 was also configured in the containers, but this endpoint is not available there. See https://kubernetes.io/docs/tasks/administer-cluster/dns-debugging-resolution/#known-issues for more details about the issue.
```


``` other operator
This extension now explicitly install containred and runc instead of relying they will be installed as docker.io dependencies.
```
