### PR TITLE
Introduce persona-based docs

### DIFF
--- a/.docforge/manifest.yaml
+++ b/.docforge/manifest.yaml
@@ -1,6 +1,12 @@
 structure:
 - name: _index.md
   source: /README.md
-- name: docs
+- name: usage
+  properties:
+    frontmatter:
+      title: Usage
+      weight: 3
+      categories:
+        - Users
   nodesSelector:
-    path: /docs
+    path: /docs/usage

--- a/docs/usage/usage.md
+++ b/docs/usage/usage.md
@@ -8,7 +8,7 @@ In this document we describe how this configuration looks like and under which c
 
 Gardener allows you to create Ubuntu based worker nodes by:
 1. Using a Gardener managed VPC
-2. Reusing a VPC that already exists (VPC `id` specified in [InfrastructureConfig](https://github.com/gardener/gardener-extension-provider-aws/blob/master/docs/usage-as-end-user.md#infrastructureconfig)]
+2. Reusing a VPC that already exists (VPC `id` specified in [InfrastructureConfig](https://github.com/gardener/gardener-extension-provider-aws/blob/master/docs/usage/usage.md#infrastructureconfig)]
 
 If the second option applies to your use-case please make sure that your VPC has enabled **DNS Support**. Otherwise Ubuntu based nodes aren't able to join or operate in your cluster properly.
 


### PR DESCRIPTION
**What this PR does / why we need it**:
We would like to introduce persona-based docs focussing on the already known release notes personas and therefore "cleanup" the structure somewhat:
- users (`/docs/usage`)
- operators (`/docs/operations`)
- developers (`/docs/development`)

**Special notes for your reviewer**:
cc @n-boshnakov

**Release note**:
None as ~30 PRs have/will be opened and the message would be the same everywhere (no relevant content changes either) while the only thing that actually changes in the end is the docs page that will have its release note.

/kind/cleanup
