### PR TITLE
Add dependabot to manage Gardener packages

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+# Create PRs for github.com/gardener/gardener dependency updates
+- package-ecosystem: gomod
+  directory: /
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 5
+  allow:
+  - dependency-name: "github.com/gardener/gardener"
+# Create PRs for golang version updates
+- package-ecosystem: docker
+  directory: /
+  schedule:
+    interval: daily

--- a/.github/workflows/vendor_gardener.yaml
+++ b/.github/workflows/vendor_gardener.yaml
@@ -1,0 +1,35 @@
+name: Vendor Gardener
+on:
+  push:
+    branches:
+    - dependabot/go_modules/github.com/gardener/**
+permissions: write-all
+jobs:
+  run:
+    name: Run make revendor
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-go@v3
+      with:
+        go-version-file: go.mod
+
+    - name: Use gardener's replaced client-go version
+      run: go mod edit -replace 'k8s.io/client-go=k8s.io/client-go@'"$(go list -m -f '{{.Version}}' k8s.io/api)"
+
+    - name: Make revendor
+      run: make revendor
+    - name: Commit changes
+      run: |
+        # Exit early if there is nothing to commit. This can happen if someone pushes to the dependabot's PR (for example has to adapt to a breaking change).
+        if [[ -z $(git status --porcelain) ]]; then
+          echo "Nothing to commit, working tree clean. Exiting..."
+          exit 0
+        fi
+        
+        git config user.name gardener-robot-ci-1
+        git config user.email gardener.ci.user@gmail.com
+
+        git add .
+        git commit -m "[dependabot skip] make revendor"
+        git push origin


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area os
/kind technical-debt
/os suse-chost

**What this PR does / why we need it**:

Integrates the changes pushed to gardener-extension-os-gardenlinux by @Kostov6 and @ialidzhikov into the ubuntu extension to have dependabot take care of up-to-date Gardener dependencies.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
