### PR TITLE
Publish Helm charts as OCI artifacts

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -1,4 +1,16 @@
 gardener-extension-os-ubuntu:
+  templates: 
+    helmcharts:
+    - &os-ubuntu
+      name: os-ubuntu
+      dir: charts/gardener-extension-os-ubuntu
+      registry: europe-docker.pkg.dev/gardener-project/snapshots/charts/gardener/extensions
+      mappings:
+      - ref: ocm-resource:gardener-extension-os-ubuntu.repository
+        attribute: image.repository
+      - ref: ocm-resource:gardener-extension-os-ubuntu.tag
+        attribute: image.tag
+
   base_definition:
     traits:
       version:
@@ -25,11 +37,17 @@ gardener-extension-os-ubuntu:
         draft_release: ~
         options:
           public_build_logs: true
+        publish:
+          helmcharts:
+          - *os-ubuntu
     pull-request:
       traits:
         pull-request: ~
         options:
           public_build_logs: true
+        publish:
+          helmcharts:
+          - *os-ubuntu
     release:
       traits:
         version:
@@ -51,3 +69,6 @@ gardener-extension-os-ubuntu:
             gardener-extension-os-ubuntu:
               image: europe-docker.pkg.dev/gardener-project/releases/gardener/extensions/os-ubuntu
               tag_as_latest: true
+          helmcharts:
+          - <<: *os-ubuntu
+            registry: europe-docker.pkg.dev/gardener-project/releases/charts/gardener/extensions


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area os delivery
/kind enhancement
/os ubuntu

**What this PR does / why we need it**:
We should start publishing Helm charts as OCI artifacts that we can deploy them as `Extension` in the future (see https://github.com/gardener/gardener/issues/9635).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Helm charts of extension and admission controller are published as OCI artifacts now.
```
