### PR TITLE
Make apt configurable

### DIFF
--- a/charts/gardener-extension-os-ubuntu/values.yaml
+++ b/charts/gardener-extension-os-ubuntu/values.yaml
@@ -12,6 +12,20 @@ config: {}
 #    ntpd:
 #      servers:
 #        - ptbtime1.ptb.de
+#  apt:
+#    preserveSourcesList: false
+#    primary:
+#      - arches: [ default ]
+#        uri: http://packages.ubuntu-mirror.example.com/apt-mirror/ubuntu
+#        search:
+#          - http://packages.ubuntu-mirror.example.com/apt-mirror/ubuntu
+#        searchDNS: true
+#    security:
+#      - arches: [ default ]
+#        uri: http://packages.ubuntu-mirror.example.com/apt-mirror/ubuntu
+#        search:
+#          - http://packages.ubuntu-mirror.example.com/apt-mirror/ubuntu
+#        searchDNS: true
 
 
 vpa:

--- a/pkg/controller/config/v1alpha1/types.go
+++ b/pkg/controller/config/v1alpha1/types.go
@@ -22,6 +22,9 @@ type ExtensionConfig struct {
 	// DisableUnattendedUpgrades to disable unattended upgrades in ubuntu
 	// +optional
 	DisableUnattendedUpgrades *bool `json:"disableUnattendedUpgrades,omitempty"`
+	// Mirror to set custom Ubuntu mirror
+	// +optional
+	ATPConfig APTConfig `json:"apt,omitempty"`
 }
 
 // NTPConfig General NTP Config for either systemd-timesyncd or ntpd
@@ -37,4 +40,39 @@ type NTPConfig struct {
 type NTPDConfig struct {
 	// Servers List of ntp servers
 	Servers []string `json:"servers"`
+}
+
+type APTConfig struct {
+	PreserveSourcesList bool         `json:"preserveSourcesList,omitempty"`
+	Primary             []APTArchive `json:"primary,omitempty"`
+	Security            []APTArchive `json:"security,omitempty"`
+}
+
+type APTArchive struct {
+	Arches    []string `json:"arches,omitempty"`
+	URI       string   `json:"uri,omitempty"`
+	Search    []string `json:"search,omitempty"`
+	SearchDNS bool     `json:"searchDNS,omitempty"`
+}
+
+type APTConfigSnake struct {
+	PreserveSourcesList bool              `json:"preserve_sources_list"`
+	Primary             []APTArchiveSnake `json:"primary,omitempty"`
+	Security            []APTArchiveSnake `json:"security,omitempty"`
+}
+
+type APTArchiveSnake struct {
+	Arches    []string `json:"arches,omitempty"`
+	URI       string   `json:"uri,omitempty"`
+	Search    []string `json:"search,omitempty"`
+	SearchDNS bool     `json:"search_dns,omitempty"`
+}
+
+type APTCloudInit struct {
+	APT APTConfigSnake `json:"apt,omitempty"`
+}
+
+type FilePart struct {
+	Type    string `json:"type"`
+	Content string `json:"content"`
 }

--- a/pkg/controller/operatingsystemconfig/actuator.go
+++ b/pkg/controller/operatingsystemconfig/actuator.go
@@ -8,7 +8,9 @@ import (
 	"context"
 	_ "embed"
 	"fmt"
+	"k8s.io/apimachinery/pkg/util/json"
 	"path/filepath"
+	"sigs.k8s.io/yaml"
 	"strings"
 	"text/template"
 
@@ -89,6 +91,43 @@ func (a *actuator) Restore(ctx context.Context, log logr.Logger, osc *extensions
 }
 
 func (a *actuator) handleProvisionOSC(ctx context.Context, osc *extensionsv1alpha1.OperatingSystemConfig) (string, error) {
+
+	aptConfig := configv1alpha1.APTConfigSnake{}
+	aptConfig.PreserveSourcesList = a.extensionConfig.ATPConfig.PreserveSourcesList
+	if len(a.extensionConfig.ATPConfig.Primary) > 0 {
+		for _, primary := range a.extensionConfig.ATPConfig.Primary {
+			archive := configv1alpha1.APTArchiveSnake{
+				Arches:    primary.Arches,
+				URI:       primary.URI,
+				Search:    primary.Search,
+				SearchDNS: primary.SearchDNS,
+			}
+			aptConfig.Primary = append(aptConfig.Primary, archive)
+		}
+	}
+	if len(a.extensionConfig.ATPConfig.Security) > 0 {
+		for _, security := range a.extensionConfig.ATPConfig.Security {
+			archive := configv1alpha1.APTArchiveSnake{
+				Arches:    security.Arches,
+				URI:       security.URI,
+				Search:    security.Search,
+				SearchDNS: security.SearchDNS,
+			}
+			aptConfig.Security = append(aptConfig.Security, archive)
+		}
+	}
+
+	cloudInit := configv1alpha1.APTCloudInit{APT: aptConfig}
+	aptData, err := json.Marshal(cloudInit)
+	if err != nil {
+		return "", err
+	}
+	yamlData, err := yaml.JSONToYAML(aptData)
+	if err != nil {
+		return "", err
+	}
+	aptString := string(yamlData)
+
 	writeFilesToDiskScript, err := operatingsystemconfig.FilesToDiskScript(ctx, a.client, osc.Namespace, osc.Spec.Files)
 	if err != nil {
 		return "", err
@@ -133,7 +172,32 @@ systemctl enable docker && systemctl restart docker
 
 	script = operatingsystemconfig.WrapProvisionOSCIntoOneshotScript(script)
 
-	return script, nil
+	cloudConfigHeader := "#cloud-config\n"
+	aptString = cloudConfigHeader + aptString
+
+	parts := []configv1alpha1.FilePart{
+		{
+			Type:    "text/x-shellscript",
+			Content: script,
+		},
+	}
+
+	if aptConfig.Primary != nil || aptConfig.Security != nil {
+		aptCloudConfig := configv1alpha1.FilePart{
+			Type:    "text/cloud-config",
+			Content: aptString,
+		}
+		parts = append(parts, aptCloudConfig)
+	}
+
+	header := "#cloud-config-archive\n"
+	yamlBody, err := yaml.Marshal(parts)
+	if err != nil {
+		return "", fmt.Errorf("error marshalling archives: %v", err)
+	}
+	archive := header + string(yamlBody)
+
+	return archive, nil
 }
 
 func (a *actuator) generateNTPConfig() (string, error) {

--- a/pkg/controller/operatingsystemconfig/actuator_test.go
+++ b/pkg/controller/operatingsystemconfig/actuator_test.go
@@ -194,6 +194,100 @@ var _ = Describe("Actuator", func() {
 				Expect(inplaceUpdateStatus).To(BeNil())
 			})
 		})
+
+		Describe("#Reconcile with custom apt config", func() {
+			expectedUserData := `#cloud-config-archive
+- content: |
+    #!/bin/bash
+    if [ -f "/var/lib/osc/provision-osc-applied" ]; then
+      echo "Provision OSC already applied, exiting..."
+      exit 0
+    fi
+
+    mkdir -p /etc/cloud/cloud.cfg.d/
+    cat <<EOF > /etc/cloud/cloud.cfg.d/custom-networking.cfg
+    network:
+      config: disabled
+    EOF
+    chmod 0644 /etc/cloud/cloud.cfg.d/custom-networking.cfg
+
+    mkdir -p "/some"
+
+    cat << EOF | base64 -d > "/some/file"
+    YmFy
+    EOF
+
+
+    cat << EOF | base64 -d > "/etc/systemd/system/some-unit"
+    Zm9v
+    EOF
+    until apt-get update -qq && apt-get install --no-upgrade -qqy containerd runc docker.io socat nfs-common logrotate jq policykit-1; do sleep 1; done
+    ln -s /usr/bin/docker /bin/docker
+
+    if [ ! -s /etc/containerd/config.toml ]; then
+      mkdir -p /etc/containerd/
+      containerd config default > /etc/containerd/config.toml
+      chmod 0644 /etc/containerd/config.toml
+    fi
+
+    mkdir -p /etc/systemd/system/containerd.service.d
+    cat <<EOF > /etc/systemd/system/containerd.service.d/11-exec_config.conf
+    [Service]
+    ExecStart=
+    ExecStart=/usr/bin/containerd --config=/etc/containerd/config.toml
+    EOF
+    chmod 0644 /etc/systemd/system/containerd.service.d/11-exec_config.conf
+
+    systemctl daemon-reload
+    systemctl enable containerd && systemctl restart containerd
+    systemctl enable docker && systemctl restart docker
+    systemctl enable 'some-unit' && systemctl restart --no-block 'some-unit'
+
+
+    mkdir -p /var/lib/osc
+    touch /var/lib/osc/provision-osc-applied
+  type: text/x-shellscript
+- content: |
+    #cloud-config
+    apt:
+      preserve_sources_list: false
+      primary:
+      - arches:
+        - default
+        uri: http://packages.ubuntu-mirror.example.com/apt-mirror/ubuntu
+      security:
+      - arches:
+        - default
+        uri: http://packages.ubuntu-mirror.example.com/apt-mirror/ubuntu
+  type: text/cloud-config
+`
+
+			It("should not return an error", func() {
+				extensionConfig := Config{ExtensionConfig: &v1alpha1.ExtensionConfig{ATPConfig: v1alpha1.APTConfig{
+					PreserveSourcesList: false,
+					Primary: []v1alpha1.APTArchive{
+						v1alpha1.APTArchive{
+							Arches: []string{"default"},
+							URI:    "http://packages.ubuntu-mirror.example.com/apt-mirror/ubuntu",
+						},
+					},
+					Security: []v1alpha1.APTArchive{
+						v1alpha1.APTArchive{
+							Arches: []string{"default"},
+							URI:    "http://packages.ubuntu-mirror.example.com/apt-mirror/ubuntu",
+						},
+					},
+				}}}
+				actuator = NewActuator(mgr, extensionConfig)
+				userData, extensionUnits, extensionFiles, inplaceUpdateStatus, err := actuator.Reconcile(ctx, log, osc)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(string(userData)).To(Equal(expectedUserData))
+				Expect(extensionUnits).To(BeEmpty())
+				Expect(extensionFiles).To(BeEmpty())
+				Expect(inplaceUpdateStatus).To(BeNil())
+			})
+		})
 	})
 
 	When("purpose is 'reconcile'", func() {

--- a/pkg/controller/operatingsystemconfig/actuator_test.go
+++ b/pkg/controller/operatingsystemconfig/actuator_test.go
@@ -58,54 +58,57 @@ var _ = Describe("Actuator", func() {
 	})
 
 	When("purpose is 'provision'", func() {
-		expectedUserData := `#!/bin/bash
-if [ -f "/var/lib/osc/provision-osc-applied" ]; then
-  echo "Provision OSC already applied, exiting..."
-  exit 0
-fi
+		expectedUserData := `#cloud-config-archive
+- content: |
+    #!/bin/bash
+    if [ -f "/var/lib/osc/provision-osc-applied" ]; then
+      echo "Provision OSC already applied, exiting..."
+      exit 0
+    fi
 
-mkdir -p /etc/cloud/cloud.cfg.d/
-cat <<EOF > /etc/cloud/cloud.cfg.d/custom-networking.cfg
-network:
-  config: disabled
-EOF
-chmod 0644 /etc/cloud/cloud.cfg.d/custom-networking.cfg
+    mkdir -p /etc/cloud/cloud.cfg.d/
+    cat <<EOF > /etc/cloud/cloud.cfg.d/custom-networking.cfg
+    network:
+      config: disabled
+    EOF
+    chmod 0644 /etc/cloud/cloud.cfg.d/custom-networking.cfg
 
-mkdir -p "/some"
+    mkdir -p "/some"
 
-cat << EOF | base64 -d > "/some/file"
-YmFy
-EOF
-
-
-cat << EOF | base64 -d > "/etc/systemd/system/some-unit"
-Zm9v
-EOF
-until apt-get update -qq && apt-get install --no-upgrade -qqy containerd runc docker.io socat nfs-common logrotate jq policykit-1; do sleep 1; done
-ln -s /usr/bin/docker /bin/docker
-
-if [ ! -s /etc/containerd/config.toml ]; then
-  mkdir -p /etc/containerd/
-  containerd config default > /etc/containerd/config.toml
-  chmod 0644 /etc/containerd/config.toml
-fi
-
-mkdir -p /etc/systemd/system/containerd.service.d
-cat <<EOF > /etc/systemd/system/containerd.service.d/11-exec_config.conf
-[Service]
-ExecStart=
-ExecStart=/usr/bin/containerd --config=/etc/containerd/config.toml
-EOF
-chmod 0644 /etc/systemd/system/containerd.service.d/11-exec_config.conf
-
-systemctl daemon-reload
-systemctl enable containerd && systemctl restart containerd
-systemctl enable docker && systemctl restart docker
-systemctl enable 'some-unit' && systemctl restart --no-block 'some-unit'
+    cat << EOF | base64 -d > "/some/file"
+    YmFy
+    EOF
 
 
-mkdir -p /var/lib/osc
-touch /var/lib/osc/provision-osc-applied
+    cat << EOF | base64 -d > "/etc/systemd/system/some-unit"
+    Zm9v
+    EOF
+    until apt-get update -qq && apt-get install --no-upgrade -qqy containerd runc docker.io socat nfs-common logrotate jq policykit-1; do sleep 1; done
+    ln -s /usr/bin/docker /bin/docker
+
+    if [ ! -s /etc/containerd/config.toml ]; then
+      mkdir -p /etc/containerd/
+      containerd config default > /etc/containerd/config.toml
+      chmod 0644 /etc/containerd/config.toml
+    fi
+
+    mkdir -p /etc/systemd/system/containerd.service.d
+    cat <<EOF > /etc/systemd/system/containerd.service.d/11-exec_config.conf
+    [Service]
+    ExecStart=
+    ExecStart=/usr/bin/containerd --config=/etc/containerd/config.toml
+    EOF
+    chmod 0644 /etc/systemd/system/containerd.service.d/11-exec_config.conf
+
+    systemctl daemon-reload
+    systemctl enable containerd && systemctl restart containerd
+    systemctl enable docker && systemctl restart docker
+    systemctl enable 'some-unit' && systemctl restart --no-block 'some-unit'
+
+
+    mkdir -p /var/lib/osc
+    touch /var/lib/osc/provision-osc-applied
+  type: text/x-shellscript
 `
 
 		Describe("#Reconcile", func() {
@@ -121,60 +124,63 @@ touch /var/lib/osc/provision-osc-applied
 		})
 
 		Describe("#Reconcile with disabled unattended upgrades", func() {
-			expectedUserData := `#!/bin/bash
-if [ -f "/var/lib/osc/provision-osc-applied" ]; then
-  echo "Provision OSC already applied, exiting..."
-  exit 0
-fi
+			expectedUserData := `#cloud-config-archive
+- content: |
+    #!/bin/bash
+    if [ -f "/var/lib/osc/provision-osc-applied" ]; then
+      echo "Provision OSC already applied, exiting..."
+      exit 0
+    fi
 
-mkdir -p /etc/cloud/cloud.cfg.d/
-cat <<EOF > /etc/cloud/cloud.cfg.d/custom-networking.cfg
-network:
-  config: disabled
-EOF
-chmod 0644 /etc/cloud/cloud.cfg.d/custom-networking.cfg
+    mkdir -p /etc/cloud/cloud.cfg.d/
+    cat <<EOF > /etc/cloud/cloud.cfg.d/custom-networking.cfg
+    network:
+      config: disabled
+    EOF
+    chmod 0644 /etc/cloud/cloud.cfg.d/custom-networking.cfg
 
-mkdir -p "/some"
+    mkdir -p "/some"
 
-cat << EOF | base64 -d > "/some/file"
-YmFy
-EOF
-
-
-cat << EOF | base64 -d > "/etc/systemd/system/some-unit"
-Zm9v
-EOF
-until apt-get update -qq && apt-get install --no-upgrade -qqy containerd runc docker.io socat nfs-common logrotate jq policykit-1; do sleep 1; done
-ln -s /usr/bin/docker /bin/docker
-
-if [ ! -s /etc/containerd/config.toml ]; then
-  mkdir -p /etc/containerd/
-  containerd config default > /etc/containerd/config.toml
-  chmod 0644 /etc/containerd/config.toml
-fi
-
-mkdir -p /etc/systemd/system/containerd.service.d
-cat <<EOF > /etc/systemd/system/containerd.service.d/11-exec_config.conf
-[Service]
-ExecStart=
-ExecStart=/usr/bin/containerd --config=/etc/containerd/config.toml
-EOF
-chmod 0644 /etc/systemd/system/containerd.service.d/11-exec_config.conf
-
-mkdir -p /etc/apt/apt.conf.d
-cat <<EOF > /etc/apt/apt.conf.d/99-auto-upgrades.conf
-APT::Periodic::Unattended-Upgrade "0";
-EOF
-chmod 0644 /etc/apt/apt.conf.d/99-auto-upgrades.conf
-
-systemctl daemon-reload
-systemctl enable containerd && systemctl restart containerd
-systemctl enable docker && systemctl restart docker
-systemctl enable 'some-unit' && systemctl restart --no-block 'some-unit'
+    cat << EOF | base64 -d > "/some/file"
+    YmFy
+    EOF
 
 
-mkdir -p /var/lib/osc
-touch /var/lib/osc/provision-osc-applied
+    cat << EOF | base64 -d > "/etc/systemd/system/some-unit"
+    Zm9v
+    EOF
+    until apt-get update -qq && apt-get install --no-upgrade -qqy containerd runc docker.io socat nfs-common logrotate jq policykit-1; do sleep 1; done
+    ln -s /usr/bin/docker /bin/docker
+
+    if [ ! -s /etc/containerd/config.toml ]; then
+      mkdir -p /etc/containerd/
+      containerd config default > /etc/containerd/config.toml
+      chmod 0644 /etc/containerd/config.toml
+    fi
+
+    mkdir -p /etc/systemd/system/containerd.service.d
+    cat <<EOF > /etc/systemd/system/containerd.service.d/11-exec_config.conf
+    [Service]
+    ExecStart=
+    ExecStart=/usr/bin/containerd --config=/etc/containerd/config.toml
+    EOF
+    chmod 0644 /etc/systemd/system/containerd.service.d/11-exec_config.conf
+
+    mkdir -p /etc/apt/apt.conf.d
+    cat <<EOF > /etc/apt/apt.conf.d/99-auto-upgrades.conf
+    APT::Periodic::Unattended-Upgrade "0";
+    EOF
+    chmod 0644 /etc/apt/apt.conf.d/99-auto-upgrades.conf
+
+    systemctl daemon-reload
+    systemctl enable containerd && systemctl restart containerd
+    systemctl enable docker && systemctl restart docker
+    systemctl enable 'some-unit' && systemctl restart --no-block 'some-unit'
+
+
+    mkdir -p /var/lib/osc
+    touch /var/lib/osc/provision-osc-applied
+  type: text/x-shellscript
 `
 			It("should not return an error", func() {
 				extensionConfig := Config{ExtensionConfig: &v1alpha1.ExtensionConfig{DisableUnattendedUpgrades: ptr.To(true)}}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area os
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area os
/kind enhancement
/os ubuntu

**What this PR does / why we need it**:
Enabling operators to configure apt configuration to use a custom Ubuntu mirror instead of the default apt settings. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
This does not have any effects if not set.
Some parts may look odd, I needed a second "snake" struct in order to parse the configuration cloud init compatible.
Simply adding the config to the existing script did not work out, as it was already too late to set an apt config, therefore I had to use a cloud config archive there.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Allows the operator to deploy nodes with custom apt configuration.
```
