### PR TITLE
chore: update build status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # [Gardener Extension for Ubuntu OS](https://gardener.cloud)
+
 [![REUSE status](https://api.reuse.software/badge/github.com/gardener/gardener-extension-os-ubuntu)](https://api.reuse.software/info/github.com/gardener/gardener-extension-os-ubuntu)
-[![CI Build status](https://concourse.ci.gardener.cloud/api/v1/teams/gardener/pipelines/gardener-extension-os-ubuntu-master/jobs/master-head-update-job/badge)](https://concourse.ci.gardener.cloud/teams/gardener/pipelines/gardener-extension-os-ubuntu-master/jobs/master-head-update-job)
+[![Build status](https://github.com/gardener/gardener-extension-os-ubuntu/actions/workflows/non-release.yaml/badge.svg?branch=master)](https://github.com/gardener/gardener-extension-os-ubuntu/actions/workflows/non-release.yaml)
 [![Go Report Card](https://goreportcard.com/badge/github.com/gardener/gardener-extension-os-ubuntu)](https://goreportcard.com/report/github.com/gardener/gardener-extension-os-ubuntu)
 
 This controller operates on the [`OperatingSystemConfig`](https://github.com/gardener/gardener/blob/master/docs/proposals/01-extensibility.md#cloud-config-user-data-for-bootstrapping-machines) resource in the `extensions.gardener.cloud/v1alpha1` API group. It manages those objects that are requesting [Ubuntu OS](https://www.ubuntu.com/) configuration (`.spec.type=ubuntu`). An experimental support for Ubuntu Pro is added (`.spec.type=ubuntu-pro`):


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area os
/kind cleanup
/os ubuntu

**What this PR does / why we need it**:

Updates the CI status badge to point to GitHub actions after the changeover from Concourse.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
