### PR TITLE
Fix multiple interfaces in ntpd config

### DIFF
--- a/pkg/controller/operatingsystemconfig/actuator_test.go
+++ b/pkg/controller/operatingsystemconfig/actuator_test.go
@@ -374,7 +374,9 @@ restrict [::1]
 
 interface ignore wildcard
 interface listen 127.0.0.1
-interface listen dev1 dev2`,
+interface listen dev1
+interface listen dev2
+`,
 						},
 					},
 				}))

--- a/pkg/controller/operatingsystemconfig/templates/ntp-config.conf.tpl
+++ b/pkg/controller/operatingsystemconfig/templates/ntp-config.conf.tpl
@@ -10,5 +10,7 @@ restrict [::1]
 {{ if .Interfaces -}}
 interface ignore wildcard
 interface listen 127.0.0.1
-interface listen {{ .Interfaces | join " " }}
+{{ range .Interfaces -}}
+interface listen {{ . }}
+{{ end -}}
 {{- end }}


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test|dependency-update
-->
/area os
/kind bug
/os ubuntu

**What this PR does / why we need it**:

The extension allow to set multiple interfaces for `ntpd`. 

Currently this will end up in `/etc/ntp.conf` like this:
```
interface listen dev1 dev2
```
`ntpd` is only using the first interface (in that case `dev1`) but ignores all others.
To listen on multiple interfaces we need to add one `interface listen` per interface. Like this:

```
interface listen dev1
interface listen dev2
```

I also opened a PR for `os-coreos`: https://github.com/gardener/gardener-extension-os-coreos/pull/284

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fix multiple interfaces in ntpd config
```
