### PR TITLE
Offboarding/duc

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
 # gardener-extension-os-ubuntu maintainers
-* @nschad @robinschneider @dergeberl @gardener/gardener-extension-os-ubuntu-maintainers
+* @dergeberl @nschad @ftl @xoxys @breuerfelix @aniruddha2000

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -2,16 +2,24 @@
 
 aliases:
   gardener-extension-os-ubuntu-reviewers:
-  - dergeberl
-  - MrBatschner
-  - nschad
-  - robinschneider
-  - Roncossek
-  - Vincinator
+    - Duciwuci
+    - einfachnuralex
+    - hown3d
+    - JuliusSte
+    - Kumm-Kai
+    - maboehm
+    - MichaelEischer
+    - rgroemmer
+    - robinschneider
+    - timebertt
+    - lukasjarosch
+    - crigertg
+    - cerealsnow
+    - jastBytes
   gardener-extension-os-ubuntu-approvers:
-  - dergeberl
-  - MrBatschner
-  - nschad
-  - robinschneider
-  - Roncossek
-  - Vincinator
+    - dergeberl
+    - nschad
+    - ftl
+    - xoxys
+    - aniruddha2000
+    - breuerfelix

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -2,7 +2,6 @@
 
 aliases:
   gardener-extension-os-ubuntu-reviewers:
-    - Duciwuci
     - einfachnuralex
     - hown3d
     - JuliusSte


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Categorize your change, e.g.:
/label rrwg-change
Normal changes do not require a label.  
More info here https://developers.stackit.schwarz/domains/runtime/ske/processes/change-process/

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind cleanup

**What this PR does / why we need it**:
Offboard Duciwuci from ske-components owner aliases.

**Related work items**:
<!--
If this change is not associated with a JIRA work item, please link the triggering alert or customer ticket instead.
-->
Part of [STACKITSKE-8363](https://jira.schwarz/browse/STACKITSKE-8363)

**Special notes for your reviewer**:

**Breaking changes**:
<!--
If your PR contains breaking changes, list the changes in detail here.
This could be:
- the change comes with an impact on customers (e.g., control plane downtime, worker node rollout), that we need to announce properly
- the stage-specific configuration needs to be adapted to this change (e.g., additional configuration is need per-stage, a field configured per stage was renamed/removed, a required env substitution is added/renamed/removed)
Also, explain how to adapt to the breaking changes in ske-stages.

Additionally, add the breaking label for the release note generation via:
/label breaking
-->

**Manual steps after rollout**:
<!-- 
If your PR contains changes that require manual steps after the rollout, list the steps in detail here.
Also, check for necessary cleanups.
-->
